### PR TITLE
specifiy logging driver - json-file

### DIFF
--- a/quickstart/docker.compose.yml
+++ b/quickstart/docker.compose.yml
@@ -71,6 +71,7 @@ services:
       - APIM_SERVER_CONNECTOR_AUTH_AUDIENCE=platform-api-server
       - APIM_SERVER_CONNECTOR_AUTH_SECRET=myConnectorAuthJwtSecret
     logging:
+      driver: "json-file"
       options:
         max-size: "10m"
         max-file: "3"
@@ -101,6 +102,7 @@ services:
       - AUTH_DISCOVERY_OIDC_URL=https://dev-1.okta.com/x/oauth2/default/.well-known/openid-configuration
       # - APIS_PROXY_MODE=false
     logging:
+      driver: "json-file"
       options:
         max-size: "10m"
         max-file: "3"


### PR DESCRIPTION
Added a logging-driver type into the docker compose as older versions of docker seem to default to a different driver (syslog) and in that case the docker compose failed with `Error response from daemon: unknown log opt 'max-file' for journald log driver`